### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/actions/get_definitions.yaml
+++ b/actions/get_definitions.yaml
@@ -1,6 +1,6 @@
 ---
   name: "get_definitions"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Retrieve definitions from urbandict for the provided term."
   enabled: true
   entry_point: "get_definitions.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - urban dict
   - urban dictionary
   - puns
-version : 0.1.0
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.