### PR TITLE
persist git config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             - home/circleci/virtualenv
             - tmp/st2
             - home/circleci/repo
+            - home/circleci/.gitconfig
 
   deploy:
     docker:


### PR DESCRIPTION
Persist git config so it can be re-used in deployment step